### PR TITLE
Update service file and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ You need to have at least **python 3.6** installed to use System Sensors.
 
 # Installation:
 
-1. Clone this repo >> git clone https://github.com/Sennevds/system_sensors.git
-2. cd system_sensors
-3. pip3 install -r requirements.txt
-4. sudo apt-get install python3-apt
-5. Edit settings_example.yaml in "~/system_sensors/src" to reflect your setup and save as settings.yaml:
+1. Clone this repo >> `git clone https://github.com/Sennevds/system_sensors.git`
+2. `cd system_sensors`
+3. `pip3 install -r requirements.txt`
+4. `sudo apt-get install python3-apt`
+5. Edit `settings_example.yaml` in `~/system_sensors/src` to reflect your setup and save as settings.yaml:
 
 | Value                           | Required | Default | Description                                                                                                                                     |
 | ------------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -57,12 +57,12 @@ You need to have at least **python 3.6** installed to use System Sensors.
 | update_interval                 | false    | 60      | The update interval to send new values to the MQTT broker                                                                                       |
 | sensors                         | false    | \       | Enable/disable individual sensors (see example settings.yaml for how-to). Default is true for all sensors.                                      |
 
-6. python3 src/system_sensors.py src/settings.yaml
+6. `python3 src/system_sensors.py src/settings.yaml`
 7. (optional) create service to autostart the script at boot:
-   1. sudo cp example_system_sensors.service /etc/systemd/system/system_sensors.service
-   2. edit the path to your script path and settings.yaml. Also make sure you replace pi in "User=pi" with the account from which this script will be run. This is typically 'pi' on default raspbian system.
-   3. sudo systemctl enable system_sensors.service
-   4. sudo systemctl start system_sensors.service
+   1. `sudo cp example_system_sensors.service /etc/systemd/system/system_sensors.service`
+   2. edit the path to your script path and settings.yaml `sudo nano /etc/systemd/system/system_sensors.service` - if you are using a Raspberry Pi the defaults should just work.
+   3. `sudo systemctl enable system_sensors.service`
+   4. `sudo systemctl start system_sensors.service`
 
 # Home Assistant configuration:
 

--- a/example_system_sensors.service
+++ b/example_system_sensors.service
@@ -3,9 +3,9 @@ Description=System Sensor service
 After=multi-user.target
 
 [Service]
-User=gughan
+User=pi
 Type=idle
-ExecStart=/usr/bin/python3 /home/gughan/system_sensors/src/system_sensors.py /home/gughan/system_sensors/src/settings.yaml
+ExecStart=/usr/bin/python3 /home/pi/system_sensors/src/system_sensors.py /home/pi/system_sensors/src/settings.yaml
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Updated the default name and paths in the service file to those of a Raspberry Pi; more people using a `pi` user than `gughan` ;-)
- Added code tags around command in README to make the copying easier

# Commits
- fix(sensor-service): update default user to pi
- fix(readme): made readme more bullet proof and updated with changes made in the service
