### PR TITLE
service user and path fix

### DIFF
--- a/example_system_sensors.service
+++ b/example_system_sensors.service
@@ -3,9 +3,9 @@ Description=System Sensor service
 After=multi-user.target
 
 [Service]
-User=gughan
+User=pi
 Type=idle
-ExecStart=/usr/bin/python3 /home/gughan/system_sensors/src/system_sensors.py /home/gughan/system_sensors/src/settings.yaml
+ExecStart=/usr/bin/python3 /home/pi/Github/system_sensors/src/system_sensors.py /home/pi/Github/system_sensors/src/settings.yaml
 
 [Install]
 WantedBy=multi-user.target

--- a/example_system_sensors.service
+++ b/example_system_sensors.service
@@ -5,7 +5,7 @@ After=multi-user.target
 [Service]
 User=pi
 Type=idle
-ExecStart=/usr/bin/python3 /home/pi/Github/system_sensors/src/system_sensors.py /home/pi/Github/system_sensors/src/settings.yaml
+ExecStart=/usr/bin/python3 /home/pi/system_sensors/src/system_sensors.py /home/pi/system_sensors/src/settings.yaml
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The example_system_sensors.service referenced a specific user and used that user on the listed paths. I set both back to assume User=pi and default path is /home/pi/system_sensors/

Feel free to reject if this breaks something, its just a small fix to an issue I encountered when setting this up. 

Fixes #130 