### PR TITLE
return load avg as number, set the unit as 'processes'

### DIFF
--- a/src/sensors.py
+++ b/src/sensors.py
@@ -126,7 +126,7 @@ def get_memory_usage():
     return str(psutil.virtual_memory().percent)
 
 def get_load(arg):
-    return str(psutil.getloadavg()[arg])
+    return psutil.getloadavg()[arg]
 
 def get_net_data(arg):
     global old_net_data
@@ -249,16 +249,19 @@ sensors = {
                  'function': get_cpu_usage},
           'load_1m':
                 {'name': 'Load 1m',
+                 'unit': 'processes',
                  'icon': 'cpu-64-bit',
                  'sensor_type': 'sensor',
                  'function': lambda: get_load(0)},
           'load_5m':
                 {'name': 'Load 5m',
+                 'unit': 'processes',
                  'icon': 'cpu-64-bit',
                  'sensor_type': 'sensor',
                  'function': lambda: get_load(1)},
           'load_15m':
                 {'name': 'Load 15m',
+                 'unit': 'processes',
                  'icon': 'cpu-64-bit',
                  'sensor_type': 'sensor',
                  'function': lambda: get_load(2)},


### PR DESCRIPTION
Quick fix #138 - removes the ´str()´ for the return value and specify the unit for load average as ´processes´ (from https://psutil.readthedocs.io/en/latest/index.html?highlight=load#psutil.getloadavg) 

BTW, I don't know if the str() conversion was on purpose and if it was the case, why it was necessary?

HA now shows the value as numeric and graphs accordingly:
![image](https://user-images.githubusercontent.com/702586/202052840-88c95a5e-2934-4555-9ebe-f234e9c71ff2.png)
  