### PR TITLE
Add rounding to the avarage load values

### DIFF
--- a/src/sensors.py
+++ b/src/sensors.py
@@ -151,7 +151,7 @@ def get_memory_usage():
     return str(psutil.virtual_memory().percent)
 
 def get_load(arg):
-    return psutil.getloadavg()[arg] / psutil.cpu_count() * 100
+    return round(psutil.getloadavg()[arg] / psutil.cpu_count() * 100, 1)
 
 def get_net_data(arg):
     global old_net_data


### PR DESCRIPTION
Addon to #150

Needed to add a rounding to the load to avoid loooong fraction numbers which are not giving any value.

Now: `17,1000000002` --> `17,1`
