### PR TITLE
Add additional_temperatures feature

### DIFF
--- a/src/settings_example.yaml
+++ b/src/settings_example.yaml
@@ -40,3 +40,7 @@ sensors:
     # Drive1: /media/storage
     # For ZFS Pools use the format:
     # pool-name: /mount-point
+  additional_temperatures:
+    # Use psutil.sensors_temperatures() to find out the name, e.g.:
+    # - cpu
+    # - bms


### PR DESCRIPTION
mostly I copy pasted from external drives sensors logics 😅 

I needed this because my Rock Pi 4 has a `cpu` sensor name. While I think that could be as simple as adding it to the whitelist, I have a plan to buy a different SBCs, that might also have different sensor name...
Also, I want to install this on several Android devices, because I want to track their battery temperatures

btw, other changes:
* remove old comment about the old way of reading temperature
  (git already has history for this, so we don't need it anymore?)
* refactor the sensor enabled checking on a separate function
* refactor `get_temp` so that it can read other temperatures

let me know if you need anything else 😉 