### PR TITLE
Remove WiFi SSID class

### DIFF
--- a/src/sensors.py
+++ b/src/sensors.py
@@ -450,8 +450,7 @@ sensors = {
                  'sensor_type': 'sensor',
                  'function': get_wifi_strength},
           'wifi_ssid':
-                {'class': 'signal_strength',
-                 'name':'Wifi SSID',
+                {'name':'Wifi SSID',
                  'icon': 'wifi',
                  'sensor_type': 'sensor',
                  'function': get_wifi_ssid},


### PR DESCRIPTION
WiFi SSID is currently designated as class: `signal_strength`. When the MQTT values are parsed in Home Assistant, HA attempts to convert the SSID to a number. `signal_strength` sensors are expected to be numeric values.