### PR TITLE
Fix Display Switch MQTT JSON payload

### DIFF
--- a/src/sensors.py
+++ b/src/sensors.py
@@ -324,10 +324,7 @@ sensors = {
                  'sensor_type': 'switch',
                  'function': get_display_status,
                  'prop': PropertyBag({
-                     'availability_topic' : "system-sensors/sensor/{device_name}/availability",
                      'command_topic'      : 'system-sensors/sensor/{device_name}/command',
-                     'state_topic'        : 'system-sensors/sensor/{device_name}/state',
-                     'value_template'     : '{{value_json.display}}',
                      'state_off'          : '0',
                      'state_on'           : '1',
                      'payload_off'        : 'display_off',

--- a/src/sensors.py
+++ b/src/sensors.py
@@ -11,11 +11,14 @@ import datetime as dt
 import sys
 import os
 import shutil
+import json
 # import os.path
 
-class ProperyBag(dict):
+class PropertyBag(dict):
     def to_string(self, device_name:str):
-        return str.replace(str.replace(str.replace(self.__str__(), "{device_name}", device_name), "{", ''), "}", '')
+        for key in self.keys():
+            self[key] = str.replace(self[key], "{device_name}", device_name)
+        return str.replace(str.replace(json.dumps(self), "{", ''), "}", '')
 
 # Only needed if using alternate method of obtaining CPU temperature (see commented out code for approach)
 #from os import walk
@@ -320,7 +323,7 @@ sensors = {
                  'icon': 'monitor',
                  'sensor_type': 'switch',
                  'function': get_display_status,
-                 'prop': ProperyBag({
+                 'prop': PropertyBag({
                      'availability_topic' : "system-sensors/sensor/{device_name}/availability",
                      'command_topic'      : 'system-sensors/sensor/{device_name}/command',
                      'state_topic'        : 'system-sensors/sensor/{device_name}/state',

--- a/src/system_sensors.py
+++ b/src/system_sensors.py
@@ -73,7 +73,7 @@ def send_config_message(mqttClient):
                     topic=f'homeassistant/{attr["sensor_type"]}/{devicename}/{sensor}/config',
                     payload = (f'{{'
                             + (f'"device_class":"{attr["class"]}",' if 'class' in attr else '')
-			    + (f'"state_class":"{attr["state_class"]}",' if 'state_class' in attr else '')
+			                + (f'"state_class":"{attr["state_class"]}",' if 'state_class' in attr else '')
                             + f'"name":"{deviceNameDisplay} {attr["name"]}",'
                             + f'"state_topic":"system-sensors/sensor/{devicename}/state",'
                             + (f'"unit_of_measurement":"{attr["unit"]}",' if 'unit' in attr else '')
@@ -83,10 +83,10 @@ def send_config_message(mqttClient):
                             + f'"device":{{"identifiers":["{devicename}_sensor"],'
                             + f'"name":"{deviceNameDisplay} Sensors","model":"{deviceModel}", "manufacturer":"{deviceManufacturer}"}}'
                             + (f',"icon":"mdi:{attr["icon"]}"' if 'icon' in attr else '')
-                    		    + (f',{attr["prop"]}' if 'prop' in attr else '')
+                            + (f',{attr["prop"].to_string(devicename)}' if 'prop' in attr else '')
                             + f'}}'
                             ),
-                    qos=1,
+                    qos=1,                                                                      
                     retain=True,
                 )
         except Exception as e:

--- a/src/system_sensors.py
+++ b/src/system_sensors.py
@@ -72,21 +72,21 @@ def send_config_message(mqttClient):
                 mqttClient.publish(
                     topic=f'homeassistant/{attr["sensor_type"]}/{devicename}/{sensor}/config',
                     payload = (f'{{'
-                            + (f'"device_class":"{attr["class"]}",' if 'class' in attr else '')
-			                + (f'"state_class":"{attr["state_class"]}",' if 'state_class' in attr else '')
-                            + f'"name":"{deviceNameDisplay} {attr["name"]}",'
-                            + f'"state_topic":"system-sensors/sensor/{devicename}/state",'
-                            + (f'"unit_of_measurement":"{attr["unit"]}",' if 'unit' in attr else '')
-                            + f'"value_template":"{{{{value_json.{sensor}}}}}",'
-                            + f'"unique_id":"{devicename}_{attr["sensor_type"]}_{sensor}",'
-                            + f'"availability_topic":"system-sensors/sensor/{devicename}/availability",'
-                            + f'"device":{{"identifiers":["{devicename}_sensor"],'
-                            + f'"name":"{deviceNameDisplay} Sensors","model":"{deviceModel}", "manufacturer":"{deviceManufacturer}"}}'
-                            + (f',"icon":"mdi:{attr["icon"]}"' if 'icon' in attr else '')
-                            + (f',{attr["prop"].to_string(devicename)}' if 'prop' in attr else '')
-                            + f'}}'
-                            ),
-                    qos=1,                                                                      
+                                + (f'"device_class":"{attr["class"]}",' if 'class' in attr else '')
+                                + (f'"state_class":"{attr["state_class"]}",' if 'state_class' in attr else '')
+                                + f'"name":"{deviceNameDisplay} {attr["name"]}",'
+                                + f'"state_topic":"system-sensors/sensor/{devicename}/state",'
+                                + (f'"unit_of_measurement":"{attr["unit"]}",' if 'unit' in attr else '')
+                                + f'"value_template":"{{{{value_json.{sensor}}}}}",'
+                                + f'"unique_id":"{devicename}_{attr["sensor_type"]}_{sensor}",'
+                                + f'"availability_topic":"system-sensors/sensor/{devicename}/availability",'
+                                + f'"device":{{"identifiers":["{devicename}_sensor"],'
+                                + f'"name":"{deviceNameDisplay} Sensors","model":"{deviceModel}", "manufacturer":"{deviceManufacturer}"}}'
+                                + (f',"icon":"mdi:{attr["icon"]}"' if 'icon' in attr else '')
+                                + (f',{attr["prop"].to_string(devicename)}' if 'prop' in attr else '')
+                                + f'}}'
+                    ),
+                    qos=1,
                     retain=True,
                 )
         except Exception as e:


### PR DESCRIPTION
This fix ensures that the Display Switch MQTT payload is valid JSON - there is a warning logged by Home Assistant which shows up as:

`Unable to parse JSON display: '{"name":"inverterpi Display Switch","state_topic":"system-sensors/sensor/inverterpi/state","value_template":"{{value_json.display}}","unique_id":"inverterpi_switch_display","availability_topic":"system-sensors/sensor/inverterpi/availability","device":{"identifiers":["inverterpi_sensor"],"name":"inverterpi Sensors","model":"RPI Foundation inverterpi", "manufacturer":"RPI Foundation"},"icon":"mdi:monitor",{'availability_topic': 'system-sensors/sensor/{device_name}/availability', 'command_topic': 'system-sensors/sensor/{device_name}/command', 'state_topic': 'system-sensors/sensor/{device_name}/state', 'value_template': '{{value_json.display}}', 'state_off': '0', 'state_on': '1', 'payload_off': 'display_off', 'payload_on': 'display_on'}}'`