### PR TITLE
Update code and modules because of module changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ You need to have at least **python 3.6** installed to use System Sensors.
 | mqtt:port                       | false    | 1883    | Port of the MQTT broker                                                                                                                         |
 | mqtt:user                       | false    | \       | The userlogin( if defined) for the MQTT broker                                                                                                  |
 | mqtt:password                   | false    | \       | the password ( if defined) for the MQTT broker                                                                                                  |
-| deviceName                      | true     | \       | device name is sent with topic                                                                                                                  |
+| tls                             | false    | \       | Details of TLS settings broker                                                                                                  |
+| tls:ca_certs                    | false    | \       | TLS settings ( if defined) for the MQTT broker                                                                                                  |
+| tls:certfile                    | false    | \       | TLS settings ( if defined) for the MQTT broker                                                                                                  |
+| tls:keyfile                     | false    | \       | TLS settings ( if defined) for the MQTT broker                                                                                                  |
 | client_id                       | true     | \       | client id to connect to the MQTT broker                                                                                                         |
+| ha_status                       | false    | hass    | Status topic for homeassistant, defaults to _hass_ if not set                                                                                      |
 | timezone                        | true     | \       | Your local timezone (you can find the list of timezones here: [time zones](https://gist.github.com/heyalexej/8bf688fd67d7199be4a1682b3eec7568)) |
 | power_integer_state(Deprecated) | false    | false   | Deprecated                                                                                                                                      |
 | update_interval                 | false    | 60      | The update interval to send new values to the MQTT broker                                                                                       |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-paho-mqtt==1.6.1
-psutil==5.9.4
-pytz==2022.7.1
-PyYAML==6.0
+paho-mqtt
+psutil
+pytz
+PyYAML
 rpi_bad_power==0.1.0
+importlib_metadata

--- a/src/settings_example.yaml
+++ b/src/settings_example.yaml
@@ -1,12 +1,17 @@
 mqtt:
   hostname: 127.0.0.1
-  port: 1883 #defaults to 1883
+  port: 1883        # defaults to 1883
   user: test
   password: test
+tls:
+  ca_certs:         # path/file preferrable use directory tls-files
+  certfile:         # path/file preferrable use directory tls-files
+  keyfile:          # path/file preferrable use directory tls-files
 deviceName: test
 client_id: test
+ha_status: hass     # status topic for homeassistant: defaults to hass if key is omitted
 timezone: Europe/Brussels
-update_interval: 60 #Defaults to 60
+update_interval: 60 # Defaults to 60
 sensors:
   temperature: true
   display: true

--- a/src/system_sensors.py
+++ b/src/system_sensors.py
@@ -9,6 +9,7 @@ import pathlib
 import argparse
 import threading
 import paho.mqtt.client as mqtt
+import importlib.metadata
 
 from sensors import *
 
@@ -141,6 +142,12 @@ def check_settings(settings):
         settings['sensors']['updates'] = False
     if 'power_integer_state' in settings:
         write_message_to_console('power_integer_state is deprecated please remove this option power state is now a binary_sensor!')
+    # these two may be present or not, but in case they are not, create a default
+    if 'ha_status' not in settings or settings['ha_status'] == '':
+        settings['ha_status'] = 'hass'
+    if 'tls' not in settings:
+        settings['tls'] = {}
+        settings['tls']['ca_certs'] = ''
 
 def check_zfs(mount_point):
     for disk in psutil.disk_partitions():
@@ -184,8 +191,8 @@ def get_host_model():
 def on_connect(client, userdata, flags, rc):
     if rc == 0:
         write_message_to_console('Connected to broker')
-        print("subscribing : hass/status")
-        client.subscribe('hass/status')
+        print("subscribing : " + f"{ha_status}/status")
+        client.subscribe(f"{ha_status}/status")
         print("subscribing : " + f"system-sensors/sensor/{devicename}/availability")
         mqttClient.publish(f'system-sensors/sensor/{devicename}/availability', 'online', retain=True)
         print("subscribing : " + f"system-sensors/sensor/{devicename}/command")
@@ -239,9 +246,20 @@ if __name__ == '__main__':
     deviceNameDisplay = settings['devicename']
     deviceManufacturer = "RPI Foundation" if "rasp" in OS_DATA["ID"] else OS_DATA['NAME']
     deviceModel = get_host_model()
+    ha_status = settings['ha_status']
     
 
-    mqttClient = mqtt.Client(client_id=settings['client_id'])
+    # https://eclipse.dev/paho/files/paho.mqtt.python/html/migrations.html
+    # note that with version1, mqttv3 is used and no other migration is made
+    # if paho-mqtt v1.6.x gets removed, a full code migration must be made
+    if importlib.metadata.version("paho-mqtt")[0] == '1':
+       # for paho 1.x clients
+       mqttClient = mqtt.Client(client_id=settings['client_id'])
+    else:
+       # for paho 2.x clients
+       # note that a deprecation warning gets logged 
+       mqttClient = mqtt.Client(mqtt.CallbackAPIVersion.VERSION1, client_id=settings['client_id'])
+
     mqttClient.on_connect = on_connect                      #attach function to callback
     mqttClient.on_message = on_message
     mqttClient.will_set(f'system-sensors/sensor/{devicename}/availability', 'offline', retain=True)
@@ -249,6 +267,12 @@ if __name__ == '__main__':
         mqttClient.username_pw_set(
             settings['mqtt']['user'], settings['mqtt']['password']
         )
+
+    # if ca_certs is populated, we expect the others have been populated accordingly
+    if settings['tls']['ca_certs'] != '':
+      mqttClient.tls_set(
+        ca_certs=settings['tls']['ca_certs'], certfile=settings['tls']['certfile'], keyfile=settings['tls']['keyfile']
+      )
 
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)

--- a/tls-files/.gitignore
+++ b/tls-files/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+


### PR DESCRIPTION
This PR does the following:

* Updates the code to allow the new `paho-mqtt` client v2 which had breaking changes.
Note that the code is still working if one is using the old version (1.6.x)
* Add code to make the homeassistant status name configurable.
Supersedes #168 
No breaking change, if the value is not in the config, the old default (hass) is used
* Add the ability to configure TLS for MQTT
Supersedes #168 
No breaking change if TLS is not defined in the config
* Add a `tls-files` directory including a `.gitignore` file excluding all files from git sync
This eases adding TLS certificates into a directory that are excluded from repo updates.
* Updated the `requirements.txt` file removing module versions + adding one module
This module is needed to identify a modules version (needed for paho-mqtt).
  * I am running all modules with  the latest module release available without any issues.
  Though keeping the version for `rpi_bad_power`.
* Update the README accordingly

The code runs flawless on my system (as usual 😄 )

Note, if you merge this, you maybe want to make a new release so that the changes get recognized more easily.