### PR TITLE
Add settings.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ venv.bak/
 # mypy
 .mypy_cache/
 system_sensors.service
+src/settings.yaml
 
 # ignore config directory created by docker
 /config


### PR DESCRIPTION
This is just a minor update as it adds `settings.yaml` to .gitignore.
We have a `settings_example.yaml` file and one usually just copies this according the Readme (Installation, item 6). When doing a rebase, the file will not get removed... 😅 

(Maybe to redo tagging, sorry ...)