### PR TITLE
MQTT config payload enhancements

### DIFF
--- a/src/system_sensors.py
+++ b/src/system_sensors.py
@@ -81,10 +81,11 @@ def send_config_message(mqttClient):
                     payload = (f'{{'
                                 + (f'"device_class":"{attr["class"]}",' if 'class' in attr else '')
                                 + (f'"state_class":"{attr["state_class"]}",' if 'state_class' in attr else '')
-                                + f'"name":"{deviceNameDisplay} {attr["name"]}",'
+                                + f'"name":"{attr["name"]}",'
                                 + f'"state_topic":"system-sensors/sensor/{devicename}/state",'
                                 + (f'"unit_of_measurement":"{attr["unit"]}",' if 'unit' in attr else '')
                                 + f'"value_template":"{{{{value_json.{sensor}}}}}",'
+                                + f'"object_id":"{devicename}_{attr["sensor_type"]}_{sensor}",'
                                 + f'"unique_id":"{devicename}_{attr["sensor_type"]}_{sensor}",'
                                 + f'"availability_topic":"system-sensors/sensor/{devicename}/availability",'
                                 + f'"device":{{"identifiers":["{devicename}_sensor"],'


### PR DESCRIPTION
* remove device name from the sensor name
  because HA will prepend the device name to the sensor name when needed
* add object_id to enforce the generated sensor_id
  previously HA uses unique_id only (I think), but after I'm updating it to the latest version, HA uses sensor name to generate the unique_id. So by adding object_id, it restored the previous behavior

|   | Before | After |
|---|---|---|
| **Device Page** | ![it's difficult to read these long truncated sensor names](https://github.com/Sennevds/system_sensors/assets/10087890/e7520aa0-23d0-4d06-a7be-e71ae76a7510) | ![The sensor names are no longer truncated](https://github.com/Sennevds/system_sensors/assets/10087890/1032c247-99f8-4fcc-83ec-1037122de08e) |
| **Searching Entities** | ![it's difficult to find the entity I'm looking for](https://github.com/Sennevds/system_sensors/assets/10087890/8cfa153b-9c86-4a42-8663-c9270d95d908) | ![The entity names are shorter and easier to find](https://github.com/Sennevds/system_sensors/assets/10087890/01af2db4-90c7-4ff1-ad60-8f8f998a9eca) |

let me know wdyt 😉 


