### PR TITLE
Update system_sensors.py (object_id --> default_entity_id)

### DIFF
--- a/src/system_sensors.py
+++ b/src/system_sensors.py
@@ -85,7 +85,7 @@ def send_config_message(mqttClient):
                                 + f'"state_topic":"system-sensors/sensor/{devicename}/state",'
                                 + (f'"unit_of_measurement":"{attr["unit"]}",' if 'unit' in attr else '')
                                 + f'"value_template":"{{{{value_json.{sensor}}}}}",'
-                                + f'"object_id":"{devicename}_{attr["sensor_type"]}_{sensor}",'
+                                + f'"default_entity_id":"{devicename}_{attr["sensor_type"]}_{sensor}",'
                                 + f'"unique_id":"{devicename}_{attr["sensor_type"]}_{sensor}",'
                                 + f'"availability_topic":"system-sensors/sensor/{devicename}/availability",'
                                 + f'"device":{{"identifiers":["{devicename}_sensor"],'


### PR DESCRIPTION
Fixes: #190 (Bug: deprecated option object_id to set the default entity id)

`object_id` --> `default_entity_id`

There is only one location for this ID.