### PR TITLE
fix #194 Sensors being created as unnamed_device_XX in HA

### DIFF
--- a/src/system_sensors.py
+++ b/src/system_sensors.py
@@ -85,7 +85,7 @@ def send_config_message(mqttClient):
                                 + f'"state_topic":"system-sensors/sensor/{devicename}/state",'
                                 + (f'"unit_of_measurement":"{attr["unit"]}",' if 'unit' in attr else '')
                                 + f'"value_template":"{{{{value_json.{sensor}}}}}",'
-                                + f'"default_entity_id":"{devicename}_{attr["sensor_type"]}_{sensor}",'
+                                + f'"default_entity_id":"sensor.{devicename}_{attr["sensor_type"]}_{sensor}",'
                                 + f'"unique_id":"{devicename}_{attr["sensor_type"]}_{sensor}",'
                                 + f'"availability_topic":"system-sensors/sensor/{devicename}/availability",'
                                 + f'"device":{{"identifiers":["{devicename}_sensor"],'


### PR DESCRIPTION
fixes #194  Sensors in Home Assistant are being created as sensor.unnamed_device_XX